### PR TITLE
[issue #37] Simplified the build with a Makefile + dev environment devev.sh script with aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+CC=clang
+CXX=clang++
+
+fullclean:
+	rm -rf ./build
+
+localclean:
+	cd build && mv _deps .. && rm -r ./* && mv ../_deps .
+
+cleancache:
+	cd build && rm CMakeCache.txt
+
+cmakegen:
+	mkdir -p build && cd build && (CC=${CC} CXX=${CXX} cmake .. -G "Unix Makefiles")
+
+compile: cmake
+	cd build && make -j16
+
+run: compile
+	echo && ./build/btagsil-cli
+
+sandbox: compile
+	echo && ./build/sandbox

--- a/devenv.sh
+++ b/devenv.sh
@@ -1,0 +1,13 @@
+# This script should work everywhere where there's a bash available (including Windows)
+# Its main purpose is to introduce a few quick and easy shortcuts for building and configuring BTAGSIL
+# You can source this script to make the shortcuts available in your bash:
+# `source ./devenv.sh`
+
+alias bfc="make fullclean"
+alias blc="make localclean"
+alias bcc="make cleancache"
+alias bcm="make cmakegen"
+alias bbl="make compile"
+alias brn="make run"
+alias brna="build/btagsil-cli" # functionally the same as `brn`, but can be used to pass CLI args to BTAGSIL
+alias bsb="make sandbox"


### PR DESCRIPTION
Added a short and clean Makefile + environment setup script for quick and easy config and compilation of BTAGSIL.

There are multiple short bash aliases available for quick and easy config, compilation and cleaning of the BTAGSIL repo after you `source ./devenv.sh`.