### PR TITLE
[issue #51] Implemented a pipeline system for fluid moving through stages of command execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1.0.98"
+thiserror = "2.0.12"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+
+pub enum PipelineError {
+    #[error("Input type mismatch during stage execution: expected {expected:?}, got {got:?}")]
+    StageTypeMismatch {
+        expected: &'static str,
+        got: &'static str,
+    },
+    #[error("Input/Output type mismatch between stages: expected {expected:?}, got {got:?}")]
+    PipelineIOTypeMismatch {
+        expected: &'static str,
+        got: &'static str,
+    },
+    #[error("Pipeline runtime error: {0}")]
+    RuntimeError(String),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,7 @@ fn main() -> Result<()> {
     let mut pipeline = Pipeline::new();
     pipeline.push_stage(stage(|i: i32| i + 10))?;
     pipeline.push_stage(stage(|i: i32| {
-        vec![i; 10]
-            .iter()
-            .map(|ie| ie.to_string())
-            .collect::<Vec<_>>()
+        [i; 10].iter().map(|ie| ie.to_string()).collect::<Vec<_>>()
     }))?;
     pipeline.push_stage(stage(|v: Vec<String>| v.join(" ")))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,31 @@
-fn main() {
-    println!("Hello, world!");
+pub mod errors;
+pub mod pipeline;
+
+use crate::pipeline::*;
+use anyhow::Result;
+
+// First stage: takes 13, adds 10
+// Second stage: takes result, creates vector of 10 strings of S1
+// Third stage: takes vector of strings, joins them by space
+fn main() -> Result<()> {
+    let starter = 13;
+
+    let mut pipeline = Pipeline::new();
+    pipeline.push_stage(stage(|i: i32| i + 10))?;
+    pipeline.push_stage(stage(|i: i32| {
+        vec![i; 10]
+            .iter()
+            .map(|ie| ie.to_string())
+            .collect::<Vec<_>>()
+    }))?;
+    pipeline.push_stage(stage(|v: Vec<String>| v.join(" ")))?;
+
+    let got = *pipeline
+        .run(anyr(starter))?
+        .value
+        .downcast::<String>()
+        .expect("Final main downcast failed!!");
+
+    println!("GOT!! => `{}`", got);
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,11 @@ fn main() -> Result<()> {
     let starter = 13;
 
     let mut pipeline = Pipeline::new();
-    pipeline.push_stage(stage("+10".to_owned(), |i: i32| i + 10))?;
-    pipeline.push_stage(stage("->vec".to_owned(), |i: i32| {
+    pipeline.push_stage(stage("+10", |i: i32| i + 10))?;
+    pipeline.push_stage(stage("->vec", |i: i32| {
         [i; 10].iter().map(|ie| ie.to_string()).collect::<Vec<_>>()
     }))?;
-    pipeline.push_stage(stage("join vec".to_owned(), |v: Vec<String>| v.join(" ")))?;
+    pipeline.push_stage(stage("join vec", |v: Vec<String>| v.join(" ")))?;
 
     let got = *pipeline
         .run(anyr(starter))?

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,11 @@ fn main() -> Result<()> {
     let starter = 13;
 
     let mut pipeline = Pipeline::new();
-    pipeline.push_stage(stage(|i: i32| i + 10))?;
-    pipeline.push_stage(stage(|i: i32| {
+    pipeline.push_stage(stage("+10".to_owned(), |i: i32| i + 10))?;
+    pipeline.push_stage(stage("->vec".to_owned(), |i: i32| {
         [i; 10].iter().map(|ie| ie.to_string()).collect::<Vec<_>>()
     }))?;
-    pipeline.push_stage(stage(|v: Vec<String>| v.join(" ")))?;
+    pipeline.push_stage(stage("join vec".to_owned(), |v: Vec<String>| v.join(" ")))?;
 
     let got = *pipeline
         .run(anyr(starter))?
@@ -24,5 +24,7 @@ fn main() -> Result<()> {
         .expect("Final main downcast failed!!");
 
     println!("GOT!! => `{}`", got);
+
+    println!("{}", pipeline.visualize());
     Ok(())
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,131 @@
+use crate::errors::PipelineError;
+use std::any::Any;
+use std::any::TypeId;
+use std::fmt::Display;
+
+pub struct AnyResult {
+    pub value: Box<dyn Any>,
+    pub type_name: &'static str,
+}
+impl AnyResult {
+    pub fn new<T: 'static + Send>(value: T) -> Self {
+        Self {
+            value: Box::new(value),
+            type_name: std::any::type_name::<T>(),
+        }
+    }
+}
+pub fn anyr<T: 'static + Send>(value: T) -> AnyResult {
+    AnyResult::new(value)
+}
+
+pub trait Stage: Send {
+    fn visualize(&self) -> String;
+    fn run(&self, input: AnyResult) -> Result<AnyResult, PipelineError>;
+    fn input_typeid(&self) -> TypeId;
+    fn input_typename(&self) -> &'static str;
+    fn output_typeid(&self) -> TypeId;
+    fn output_typename(&self) -> &'static str;
+}
+
+pub struct StageImpl<I, O, F>
+where
+    I: 'static + Send,
+    O: 'static + Send,
+    F: Fn(I) -> O + Send + 'static,
+{
+    _input: std::marker::PhantomData<I>,
+    _output: std::marker::PhantomData<O>,
+    func: F,
+}
+
+impl<I, O, F> Stage for StageImpl<I, O, F>
+where
+    I: 'static + Send,
+    O: 'static + Send,
+    F: Fn(I) -> O + Send + 'static,
+{
+    fn visualize(&self) -> String {
+        std::any::type_name::<F>().to_string()
+    }
+
+    fn run(&self, input: AnyResult) -> Result<AnyResult, PipelineError> {
+        let extracted =
+            input
+                .value
+                .downcast::<I>()
+                .map_err(|_| PipelineError::StageTypeMismatch {
+                    expected: std::any::type_name::<I>(),
+                    got: input.type_name,
+                })?;
+        let processed = (self.func)(*extracted);
+        Ok(anyr(processed))
+    }
+
+    fn input_typeid(&self) -> TypeId {
+        TypeId::of::<I>()
+    }
+    fn input_typename(&self) -> &'static str {
+        std::any::type_name::<I>()
+    }
+
+    fn output_typeid(&self) -> TypeId {
+        TypeId::of::<O>()
+    }
+    fn output_typename(&self) -> &'static str {
+        std::any::type_name::<O>()
+    }
+}
+
+impl Display for dyn Stage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.visualize())
+    }
+}
+
+pub fn stage<I, O, F>(func: F) -> Box<dyn Stage>
+where
+    I: 'static + Send,
+    O: 'static + Send,
+    F: Fn(I) -> O + Send + 'static,
+{
+    Box::new(StageImpl::<I, O, F> {
+        _input: Default::default(),
+        _output: Default::default(),
+        func,
+    })
+}
+
+// TODO: create a nice wrapper around the pipeline/stages to make it nicer to use
+pub struct Pipeline {
+    stages: Vec<Box<dyn Stage>>,
+}
+
+impl Pipeline {
+    pub fn new() -> Self {
+        Self { stages: Vec::new() }
+    }
+
+    pub fn push_stage(&mut self, stage: Box<dyn Stage>) -> Result<(), PipelineError> {
+        if let Some(last) = self.stages.last() {
+            if last.output_typeid() != stage.input_typeid() {
+                return Err(PipelineError::PipelineIOTypeMismatch {
+                    expected: last.output_typename(),
+                    got: stage.input_typename(),
+                });
+            }
+        }
+
+        self.stages.push(stage);
+        Ok(())
+    }
+
+    pub fn run(&self, input: AnyResult) -> Result<AnyResult, PipelineError> {
+        let mut current = input;
+        for stage in &self.stages {
+            current = stage.run(current)?;
+        }
+
+        Ok(current)
+    }
+}

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -20,6 +20,7 @@ pub fn anyr<T: 'static + Send>(value: T) -> AnyResult {
 }
 
 pub trait Stage: Send {
+    // TODO: implement Stage name, so visializer is in the form of `StageName: {Input} -> {Output}`
     fn visualize(&self) -> String;
     fn run(&self, input: AnyResult) -> Result<AnyResult, PipelineError>;
     fn input_typeid(&self) -> TypeId;
@@ -97,6 +98,7 @@ where
 }
 
 // TODO: create a nice wrapper around the pipeline/stages to make it nicer to use
+#[derive(Default)]
 pub struct Pipeline {
     stages: Vec<Box<dyn Stage>>,
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -20,9 +20,10 @@ pub fn anyr<T: 'static + Send>(value: T) -> AnyResult {
 }
 
 pub trait Stage: Send {
-    fn name(&self) -> String;
+    fn name(&self) -> &str;
     fn visualize(&self) -> String;
     fn run(&self, input: AnyResult) -> Result<AnyResult, PipelineError>;
+
     fn input_typeid(&self) -> TypeId;
     fn input_typename(&self) -> &'static str;
     fn output_typeid(&self) -> TypeId;
@@ -47,8 +48,8 @@ where
     O: 'static + Send,
     F: Fn(I) -> O + Send + 'static,
 {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        self.name.as_str()
     }
 
     fn visualize(&self) -> String {
@@ -94,7 +95,7 @@ impl Display for dyn Stage {
     }
 }
 
-pub fn stage<I, O, F>(name: String, func: F) -> Box<dyn Stage>
+pub fn stage<I, O, F>(name: &str, func: F) -> Box<dyn Stage>
 where
     I: 'static + Send,
     O: 'static + Send,
@@ -104,7 +105,7 @@ where
         _input: Default::default(),
         _output: Default::default(),
         func,
-        name,
+        name: name.to_owned(),
     })
 }
 


### PR DESCRIPTION
Implemented a pipeline system for fluid and flexible command execution. 

- You get an input parameter.
- It passes trough stages: Stage 0 => Stage 1 => Stage 2 => ... => Stage N
- Each stage converts input from input type to output type: I => O
- The result of executing the entire pipeline is: Stage 0 Input Type => Stage N Output Type (converts to type of last stage output)

Intended use for now: Parser => Intent Analysis => World Mutation => Output text to player.
In the future, hopefully this pipeline system can be made more flexible and have many more uses than just one.